### PR TITLE
Improving the `Extend` capabilities of complex equalization profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ There are some of examples of what might be referred by this term:
 - Equalizing values of different types
 - Equalizing values of the same type when this is not a trivial task
 
-All complex equalization profiles should inherit a common base class called `ComplexEqualizationProfile<TExpected, TActual>`.
+All complex equalization profiles should inherit a base class called `ComplexEqualizationProfile<TExpected, TActual>` (it implements the corresponding `IComplexEqualizationProfile<TExpected, TActual>` interface).
 The inheritors should setup the equalization logic (throughout registering various `IComplexEqualizationRule<TExpected, TActual>` instances) in their constructor.
 There are predefined methods for equalization and differentiation that can be used directly.
 Here is one standard example:
@@ -148,7 +148,7 @@ public class CodeRepositoryEqualizationProfile : ComplexEqualizationProfile<Code
 {
     public CodeRepositoryEqualizationProfile()
     {
-        this.Extend(new CommonIdentifiableEqualizationProfile<CodeRepositoryPrototype, CodeRepository, int>());
+        this.Extend(new CommonIdentifiableEqualizationProfile<int>());
         this.Equalize(rp => rp.Name, r => r.Name);
         this.Equalize(rp => rp.Description, r => r.Description);
         this.Equalize(5, r => r.OrganizationId);

--- a/TryAtSoftware.Equalizer.Core.Tests/Profiles/CodeRepositoryEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/Profiles/CodeRepositoryEqualizationProfile.cs
@@ -8,7 +8,7 @@ public class CodeRepositoryEqualizationProfile : ComplexEqualizationProfile<Code
 {
     public CodeRepositoryEqualizationProfile()
     {
-        this.Extend(new CommonIdentifiableEqualizationProfile<CodeRepositoryPrototype, CodeRepository, int>());
+        this.Extend(new CommonIdentifiableEqualizationProfile<int>());
         this.Equalize(rp => rp.Name, r => r.Name);
         this.Equalize(rp => rp.Description, r => r.Description);
         this.Equalize(5, r => r.OrganizationId);

--- a/TryAtSoftware.Equalizer.Core.Tests/Profiles/CodeRepositoryEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/Profiles/CodeRepositoryEqualizationProfile.cs
@@ -9,8 +9,11 @@ public class CodeRepositoryEqualizationProfile : ComplexEqualizationProfile<Code
     public CodeRepositoryEqualizationProfile()
     {
         this.Extend(new CommonIdentifiableEqualizationProfile<int>());
+
+#pragma warning disable CS0618 // This directive should be removed soon. See issue #51
         this.Extend(new CodeRepositoryEqualizationProfilePart1());
         this.Extend(new CodeRepositoryEqualizationProfilePart2());
+#pragma warning restore CS0618
 
         this.Equalize(rp => rp.Description, r => r.Description);
         this.Equalize(5, r => r.OrganizationId);

--- a/TryAtSoftware.Equalizer.Core.Tests/Profiles/CodeRepositoryEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/Profiles/CodeRepositoryEqualizationProfile.cs
@@ -9,13 +9,30 @@ public class CodeRepositoryEqualizationProfile : ComplexEqualizationProfile<Code
     public CodeRepositoryEqualizationProfile()
     {
         this.Extend(new CommonIdentifiableEqualizationProfile<int>());
-        this.Equalize(rp => rp.Name, r => r.Name);
+        this.Extend(new CodeRepositoryEqualizationProfilePart1());
+        this.Extend(new CodeRepositoryEqualizationProfilePart2());
+
         this.Equalize(rp => rp.Description, r => r.Description);
         this.Equalize(5, r => r.OrganizationId);
-        this.Differentiate(rp => rp.Name, r => r.InternalName);
-        this.Differentiate(Value.Empty, r => r.InternalName);
         this.Equalize(rp => rp.CommitMessages, r => r.InitialCommits);
         this.Equalize(Value.Empty, r => r.SubsequentCommits);
+    }
+}
+
+file class CodeRepositoryEqualizationProfilePart1 : ComplexEqualizationProfile<CodeRepositoryPrototype, CodeRepository>
+{
+    public CodeRepositoryEqualizationProfilePart1()
+    {
+        this.Equalize(rp => rp.Name, r => r.Name);
+        this.Differentiate(rp => rp.Name, r => r.InternalName);
+        this.Differentiate(Value.Empty, r => r.InternalName);
+    }
+}
+
+file class CodeRepositoryEqualizationProfilePart2 : ComplexEqualizationProfile<CodeRepositoryPrototype, CodeRepository>
+{
+    public CodeRepositoryEqualizationProfilePart2()
+    {
         this.Equalize(Value.LowerThan(100), r => r.Likes);
         this.Equalize(Value.GreaterThanOrEqual(3), r => r.Likes);
     }

--- a/TryAtSoftware.Equalizer.Core.Tests/Profiles/CommonIdentifiableEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/Profiles/CommonIdentifiableEqualizationProfile.cs
@@ -3,8 +3,7 @@
 using TryAtSoftware.Equalizer.Core.Profiles.Complex;
 using TryAtSoftware.Equalizer.Core.Tests.Models;
 
-public class CommonIdentifiableEqualizationProfile<TExpected, TActual, TKey> : ComplexEqualizationProfile<TExpected, TActual>
-    where TActual : IIdentifiable<TKey>
+public class CommonIdentifiableEqualizationProfile<TKey> : ComplexEqualizationProfile<object, IIdentifiable<TKey>>
 {
     public CommonIdentifiableEqualizationProfile()
     {

--- a/TryAtSoftware.Equalizer.Core/Constants.cs
+++ b/TryAtSoftware.Equalizer.Core/Constants.cs
@@ -1,0 +1,6 @@
+﻿namespace TryAtSoftware.Equalizer.Core;
+
+internal static class Constants
+{
+    internal const string MethodWillBeRemoved = "This method will be removed with the next major release.";
+}

--- a/TryAtSoftware.Equalizer.Core/Profiles/Complex/ComplexEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Complex/ComplexEqualizationProfile.cs
@@ -88,7 +88,9 @@ public class ComplexEqualizationProfile<TExpected, TActual> : BaseTypedEqualizat
     /// </summary>
     /// <param name="commonProfile">Another <see cref="ComplexEqualizationProfile{TExpected,TActual}"/> instance this one should extend from.</param>
     /// <exception cref="ArgumentNullException">Thrown of the provided <paramref name="commonProfile"/> is null.</exception>
+#pragma warning disable S1133 // This directive should be removed soon. See issue #51
     [Obsolete(Constants.MethodWillBeRemoved)]
+#pragma warning restore S1133
     protected void Extend(ComplexEqualizationProfile<TExpected, TActual> commonProfile)
         => this.Extend((IComplexEqualizationProfile<TExpected, TActual>)commonProfile);
 

--- a/TryAtSoftware.Equalizer.Core/Profiles/Complex/ComplexEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Complex/ComplexEqualizationProfile.cs
@@ -84,6 +84,15 @@ public class ComplexEqualizationProfile<TExpected, TActual> : BaseTypedEqualizat
     }
 
     /// <summary>
+    /// Use this method to extend this complex equalization profile with some common configuration from the provided <paramref name="commonProfile"/>.
+    /// </summary>
+    /// <param name="commonProfile">Another <see cref="ComplexEqualizationProfile{TExpected,TActual}"/> instance this one should extend from.</param>
+    /// <exception cref="ArgumentNullException">Thrown of the provided <paramref name="commonProfile"/> is null.</exception>
+    [Obsolete(Constants.MethodWillBeRemoved)]
+    protected void Extend(ComplexEqualizationProfile<TExpected, TActual> commonProfile)
+        => this.Extend((IComplexEqualizationProfile<TExpected, TActual>)commonProfile);
+
+    /// <summary>
     /// Use this method to register an external <see cref="IComplexEqualizationRule{TExpected,TActual}"/>.
     /// </summary>
     /// <param name="complexEqualizationRule">The <see cref="IComplexEqualizationRule{TExpected,TActual}"/> instance to register.</param>

--- a/TryAtSoftware.Equalizer.Core/Profiles/Complex/ComplexEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Complex/ComplexEqualizationProfile.cs
@@ -11,9 +11,12 @@ using TryAtSoftware.Equalizer.Core.Profiles.Complex.Rules;
 /// </summary>
 /// <typeparam name="TExpected">The type of the expected value.</typeparam>
 /// <typeparam name="TActual">The type of the actual value.</typeparam>
-public class ComplexEqualizationProfile<TExpected, TActual> : BaseTypedEqualizationProfile<TExpected, TActual>
+public class ComplexEqualizationProfile<TExpected, TActual> : BaseTypedEqualizationProfile<TExpected, TActual>, IComplexEqualizationProfile<TExpected, TActual>
 {
     private readonly List<IComplexEqualizationRule<TExpected, TActual>> _rules = new();
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<IComplexEqualizationRule<TExpected, TActual>> Rules => this._rules.AsReadOnly();
 
     /// <inheritdoc />
     protected override IEqualizationResult Equalize(TExpected expected, TActual actual, IEqualizationOptions options)
@@ -72,12 +75,12 @@ public class ComplexEqualizationProfile<TExpected, TActual> : BaseTypedEqualizat
     /// <summary>
     /// Use this method to extend this complex equalization profile with some common configuration from the provided <paramref name="commonProfile"/>.
     /// </summary>
-    /// <param name="commonProfile">Another <see cref="ComplexEqualizationProfile{TExpected,TActual}"/> instance this one should extend from.</param>
+    /// <param name="commonProfile">Another <see cref="IComplexEqualizationProfile{TExpected,TActual}"/> instance this one should extend from.</param>
     /// <exception cref="ArgumentNullException">Thrown of the provided <paramref name="commonProfile"/> is null.</exception>
-    protected void Extend(ComplexEqualizationProfile<TExpected, TActual> commonProfile)
+    protected void Extend(IComplexEqualizationProfile<TExpected, TActual> commonProfile)
     {
         if (commonProfile is null) throw new ArgumentNullException(nameof(commonProfile));
-        foreach (var commonProfileRule in commonProfile._rules) this.AddRule(commonProfileRule);
+        foreach (var commonProfileRule in commonProfile.Rules) this.AddRule(commonProfileRule);
     }
 
     /// <summary>

--- a/TryAtSoftware.Equalizer.Core/Profiles/Complex/IComplexEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Complex/IComplexEqualizationProfile.cs
@@ -3,7 +3,15 @@
 using System.Collections.Generic;
 using TryAtSoftware.Equalizer.Core.Profiles.Complex.Rules;
 
+/// <summary>
+/// An interface defining the structure of a component responsible for equalizing complex values.
+/// </summary>
+/// <typeparam name="TExpected">The type of the expected value.</typeparam>
+/// <typeparam name="TActual">The type of the actual value.</typeparam>
 public interface IComplexEqualizationProfile<in TExpected, in TActual>
 {
+    /// <summary>
+    /// Gets a read-only collection containing all registered <see cref="IComplexEqualizationRule{TExpected,TActual}"/> instances.
+    /// </summary>
     IReadOnlyCollection<IComplexEqualizationRule<TExpected, TActual>> Rules { get; }
 }

--- a/TryAtSoftware.Equalizer.Core/Profiles/Complex/IComplexEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Complex/IComplexEqualizationProfile.cs
@@ -1,0 +1,9 @@
+﻿namespace TryAtSoftware.Equalizer.Core.Profiles.Complex;
+
+using System.Collections.Generic;
+using TryAtSoftware.Equalizer.Core.Profiles.Complex.Rules;
+
+public interface IComplexEqualizationProfile<in TExpected, in TActual>
+{
+    IReadOnlyCollection<IComplexEqualizationRule<TExpected, TActual>> Rules { get; }
+}


### PR DESCRIPTION
## Pull Request Description 

Added an `IComplexEqualizationProfile` allowing for contravariance. It is used as a part of the `Extend` method.

## Motivation and Context

It is annoying to make the extendable complex equalization profiles generic. This PR allows to extend complex equalization profiles by utilizing the concept of contravariance.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
