### PR TITLE
PoC: Invariant equalization profiles

### DIFF
--- a/TryAtSoftware.Equalizer.Benchmark/TryAtSoftware.Equalizer.Benchmark.csproj
+++ b/TryAtSoftware.Equalizer.Benchmark/TryAtSoftware.Equalizer.Benchmark.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
       <PackageReference Include="CompareNETObjects" Version="4.79.0" />
-      <PackageReference Include="TryAtSoftware.Equalizer" Version="1.0.1-alpha.3" />
+      <PackageReference Include="TryAtSoftware.Equalizer" Version="1.0.1" />
     </ItemGroup>
 
 </Project>

--- a/TryAtSoftware.Equalizer.Core.Tests/Randomization/Shopping/ShopRandomizer.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/Randomization/Shopping/ShopRandomizer.cs
@@ -9,9 +9,9 @@ public class ShopRandomizer : ComplexRandomizer<Shop>
     public ShopRandomizer()
         : base(new GeneralInstanceBuilder<Shop>())
     {
-        this.AddRandomizationRule(s => s.Id, new NumberRandomizer());
-        this.AddRandomizationRule(s => s.Name, new StringRandomizer());
-        this.AddRandomizationRule(s => s.Address, new StringRandomizer());
-        this.AddRandomizationRule(s => s.Area, new NumberRandomizer());
+        this.Randomize(s => s.Id, new NumberRandomizer());
+        this.Randomize(s => s.Name, new StringRandomizer());
+        this.Randomize(s => s.Address, new StringRandomizer());
+        this.Randomize(s => s.Area, new NumberRandomizer());
     }
 }

--- a/TryAtSoftware.Equalizer.Core.Tests/Templates/ValueTemplateEqualizationTests.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/Templates/ValueTemplateEqualizationTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace TryAtSoftware.Equalizer.Core.Tests.Templates;
 
+using System.Collections;
 using TryAtSoftware.Equalizer.Core.Interfaces;
 using TryAtSoftware.Equalizer.Core.Templates;
 using Xunit;
@@ -14,13 +15,35 @@ public class ValueTemplateEqualizationTests
     }
 
     [Theory, InlineData(null), InlineData(""), InlineData("   ")]
-    public void EmptyTextEqualizationProfileShouldWorkCorrectly(string? value)
+    public void EmptyTextEqualizationProfileShouldWorkCorrectlyWithEmptyText(string? value)
+    {
+        this._equalizer.AssertEquality(Value.Empty, value);
+        this._equalizer.AssertEquality(value, Value.Empty);
+    }
+    
+    [Fact]
+    public void EmptyTextEqualizationProfileShouldWorkCorrectlyWithNonEmptyText()
+    {
+        this._equalizer.AssertInequality(Value.Empty, "text");
+        this._equalizer.AssertInequality("text", Value.Empty);
+    }
+
+    [Theory, InlineData(null), InlineData(new object[] { new object[0] })]
+    public void EmptyCollectionEqualizationProfileShouldWorkCorrectlyWithEmptyCollection(IEnumerable? value)
     {
         this._equalizer.AssertEquality(Value.Empty, value);
         this._equalizer.AssertEquality(value, Value.Empty);
         
-        this._equalizer.AssertInequality(Value.Empty, "text");
+        this._equalizer.AssertInequality(Value.Empty, new [] { new object() });
         this._equalizer.AssertInequality("text", Value.Empty);
+    }
+    
+    [Fact]
+    public void EmptyCollectionEqualizationProfileShouldWorkCorrectlyWithNonEmptyCollection()
+    {
+        var collection = new[] { new object() };
+        this._equalizer.AssertInequality(Value.Empty, collection);
+        this._equalizer.AssertInequality(collection, Value.Empty);
     }
     
     [Fact]

--- a/TryAtSoftware.Equalizer.Core.Tests/Templates/ValueTemplateEqualizationTests.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/Templates/ValueTemplateEqualizationTests.cs
@@ -1,0 +1,77 @@
+﻿namespace TryAtSoftware.Equalizer.Core.Tests.Templates;
+
+using TryAtSoftware.Equalizer.Core.Interfaces;
+using TryAtSoftware.Equalizer.Core.Templates;
+using Xunit;
+
+public class ValueTemplateEqualizationTests
+{
+    private readonly IEqualizer _equalizer;
+
+    public ValueTemplateEqualizationTests()
+    {
+        this._equalizer = new Equalizer();
+    }
+
+    [Theory, InlineData(null), InlineData(""), InlineData("   ")]
+    public void EmptyTextEqualizationProfileShouldWorkCorrectly(string? value)
+    {
+        this._equalizer.AssertEquality(Value.Empty, value);
+        this._equalizer.AssertEquality(value, Value.Empty);
+        
+        this._equalizer.AssertInequality(Value.Empty, "text");
+        this._equalizer.AssertInequality("text", Value.Empty);
+    }
+    
+    [Fact]
+    public void LowerThanEqualizationProfileShouldWorkCorrectly()
+    {
+        this._equalizer.AssertEquality(Value.LowerThan(10), 5);
+        this._equalizer.AssertEquality(5, Value.LowerThan(10));
+        
+        this._equalizer.AssertInequality(Value.LowerThan(10), 10);
+        this._equalizer.AssertInequality(10, Value.LowerThan(10));
+        
+        this._equalizer.AssertInequality(Value.LowerThan(10), 15);
+        this._equalizer.AssertInequality(15, Value.LowerThan(10));
+    }
+    
+    [Fact]
+    public void LowerThanOrEqualEqualizationProfileShouldWorkCorrectly()
+    {
+        this._equalizer.AssertEquality(Value.LowerThanOrEqual(10), 5);
+        this._equalizer.AssertEquality(5, Value.LowerThanOrEqual(10));
+        
+        this._equalizer.AssertEquality(Value.LowerThanOrEqual(10), 10);
+        this._equalizer.AssertEquality(10, Value.LowerThanOrEqual(10));
+        
+        this._equalizer.AssertInequality(Value.LowerThanOrEqual(10), 15);
+        this._equalizer.AssertInequality(15, Value.LowerThanOrEqual(10));
+    }
+    
+    [Fact]
+    public void GreaterThanEqualizationProfileShouldWorkCorrectly()
+    {
+        this._equalizer.AssertInequality(Value.GreaterThan(10), 5);
+        this._equalizer.AssertInequality(5, Value.GreaterThan(10));
+        
+        this._equalizer.AssertInequality(Value.GreaterThan(10), 10);
+        this._equalizer.AssertInequality(10, Value.GreaterThan(10));
+        
+        this._equalizer.AssertEquality(Value.GreaterThan(10), 15);
+        this._equalizer.AssertEquality(15, Value.GreaterThan(10));
+    }
+    
+    [Fact]
+    public void GreaterThanOrEqualEqualizationProfileShouldWorkCorrectly()
+    {
+        this._equalizer.AssertInequality(Value.GreaterThanOrEqual(10), 5);
+        this._equalizer.AssertInequality(5, Value.GreaterThanOrEqual(10));
+        
+        this._equalizer.AssertEquality(Value.GreaterThanOrEqual(10), 10);
+        this._equalizer.AssertEquality(10, Value.GreaterThanOrEqual(10));
+        
+        this._equalizer.AssertEquality(Value.GreaterThanOrEqual(10), 15);
+        this._equalizer.AssertEquality(15, Value.GreaterThanOrEqual(10));
+    }
+}

--- a/TryAtSoftware.Equalizer.Core.Tests/TryAtSoftware.Equalizer.Core.Tests.csproj
+++ b/TryAtSoftware.Equalizer.Core.Tests/TryAtSoftware.Equalizer.Core.Tests.csproj
@@ -12,7 +12,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="SonarAnalyzer.CSharp" Version="9.3.0.71466" PrivateAssets="all" />
-        <PackageReference Include="TryAtSoftware.Randomizer" Version="1.0.4" />
+        <PackageReference Include="TryAtSoftware.Randomizer" Version="2.0.1" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
         <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />

--- a/TryAtSoftware.Equalizer.Core/Assertions/Assert.cs
+++ b/TryAtSoftware.Equalizer.Core/Assertions/Assert.cs
@@ -11,7 +11,7 @@ internal static class Assert
             throw new InvalidAssertException($"The variable {variableName} was not expected to be null.");
     }
 
-    public static void True(bool value, string message)
+    public static void True([DoesNotReturnIf(false)] bool value, string message)
     {
         if (!value)
             throw new InvalidAssertException(message);

--- a/TryAtSoftware.Equalizer.Core/Profiles/BaseTypedEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/BaseTypedEqualizationProfile.cs
@@ -27,6 +27,12 @@ public abstract class BaseTypedEqualizationProfile<TExpected, TActual> : IEquali
     /// </remarks>
     protected virtual bool AllowNullActual => false;
 
+    /// <summary>
+    /// Gets a value indicating whether the order of expected and actual value is invariant.
+    /// </summary>
+    /// <remarks>
+    /// If this property is <c>true</c>, this equalizer will be used for equalization of (expected>, actual) and (actual, expected) pairs of values (the order does not matter).
+    /// </remarks>
     protected virtual bool IsInvariant => false;
 
     /// <inheritdoc />

--- a/TryAtSoftware.Equalizer.Core/Profiles/Templates/EmptyCollectionEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Templates/EmptyCollectionEqualizationProfile.cs
@@ -20,4 +20,7 @@ public class EmptyCollectionEqualizationProfile : BaseTypedEqualizationProfile<E
 
     /// <inheritdoc />
     protected override bool AllowNullActual => true;
+
+    /// <inheritdoc />
+    protected override bool IsInvariant => true;
 }

--- a/TryAtSoftware.Equalizer.Core/Profiles/Templates/EmptyTextEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Templates/EmptyTextEqualizationProfile.cs
@@ -18,4 +18,7 @@ public class EmptyTextEqualizationProfile : BaseTypedEqualizationProfile<EmptyVa
 
     /// <inheritdoc />
     protected override bool AllowNullActual => true;
+
+    /// <inheritdoc />
+    protected override bool IsInvariant => true;
 }

--- a/TryAtSoftware.Equalizer.Core/Profiles/Templates/GreaterThanEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Templates/GreaterThanEqualizationProfile.cs
@@ -18,4 +18,7 @@ public class GreaterThanEqualizationProfile : BaseTypedEqualizationProfile<Great
 
         return new SuccessfulEqualizationResult();
     }
+
+    /// <inheritdoc />
+    protected override bool IsInvariant => true;
 }

--- a/TryAtSoftware.Equalizer.Core/Profiles/Templates/GreaterThanOrEqualEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Templates/GreaterThanOrEqualEqualizationProfile.cs
@@ -18,4 +18,7 @@ public class GreaterThanOrEqualEqualizationProfile : BaseTypedEqualizationProfil
 
         return new SuccessfulEqualizationResult();
     }
+
+    /// <inheritdoc />
+    protected override bool IsInvariant => true;
 }

--- a/TryAtSoftware.Equalizer.Core/Profiles/Templates/LowerThanEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Templates/LowerThanEqualizationProfile.cs
@@ -18,4 +18,7 @@ public class LowerThanEqualizationProfile : BaseTypedEqualizationProfile<LowerTh
 
         return new SuccessfulEqualizationResult();
     }
+
+    /// <inheritdoc />
+    protected override bool IsInvariant => true;
 }

--- a/TryAtSoftware.Equalizer.Core/Profiles/Templates/LowerThanOrEqualEqualizationProfile.cs
+++ b/TryAtSoftware.Equalizer.Core/Profiles/Templates/LowerThanOrEqualEqualizationProfile.cs
@@ -18,4 +18,7 @@ public class LowerThanOrEqualEqualizationProfile : BaseTypedEqualizationProfile<
 
         return new SuccessfulEqualizationResult();
     }
+
+    /// <inheritdoc />
+    protected override bool IsInvariant => true;
 }


### PR DESCRIPTION
## Pull Request Description 

Introduced a new property as a part of the `ComplexEqualizationProfile` base class - `IsInvariant`. It will indicate that the `TExpected` and `TActual` values are invariant, i.e. the order in which they are passed is not relevant.

## Motivation and Context

_[Explain in details the reasoning behind these changes and provide any relevant context. This can include potential impact or any alternative solutions considered.]_

## Checklist

- [x] I have tested these changes thoroughly.
- [ ] I have added/updated relevant documentation.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
- [x] My changes are backwards compatible.
