### PR TITLE
Replace `Moq` with `NSubstitute`

### DIFF
--- a/TryAtSoftware.Equalizer.Core.Tests/TestsCompanion.cs
+++ b/TryAtSoftware.Equalizer.Core.Tests/TestsCompanion.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Collections.Generic;
-using Moq;
+using NSubstitute;
 using TryAtSoftware.Equalizer.Core.Interfaces;
 using TryAtSoftware.Randomizer.Core.Helpers;
 using Xunit;
@@ -30,27 +30,25 @@ public static class TestsCompanion
     }
 
     public static IEqualizationProfileProvider MockEqualizationProfileProvider()
-    {
-        var profileProviderMock = new Mock<IEqualizationProfileProvider>();
-        return profileProviderMock.Object;
-    }
+        => Substitute.For<IEqualizationProfileProvider>();
 
     public static IEqualizationProfile MockEqualizationProfile(bool isExecutable = false)
     {
-        var profileMock = new Mock<IEqualizationProfile>();
-        profileMock.Setup(x => x.CanExecuteFor(It.IsAny<object>(), It.IsAny<object>())).Returns(isExecutable);
+        var profile = Substitute.For<IEqualizationProfile>();
+        profile.CanExecuteFor(Arg.Any<object>(), Arg.Any<object>()).Returns(isExecutable);
 
-        return profileMock.Object;
+        return profile;
     }
     
-    public static Mock<IEqualizationOptions> MockEqualizationOptions() => MockEqualizationOptions((_, _) => new SuccessfulEqualizationResult());
+    public static IEqualizationOptions MockEqualizationOptions() => MockEqualizationOptions((_, _) => new SuccessfulEqualizationResult());
 
-    public static Mock<IEqualizationOptions> MockEqualizationOptions(Func<object, object, IEqualizationResult> internalEqualization)
+    public static IEqualizationOptions MockEqualizationOptions(Func<object, object, IEqualizationResult> internalEqualization)
     {
-        var equalizationOptionsMock = new Mock<IEqualizationOptions>();
-        equalizationOptionsMock.Setup(eo => eo.Equalize(It.IsAny<object>(), It.IsAny<object>())).Returns(internalEqualization);
-        equalizationOptionsMock.Setup(eo => eo.ExpectedType).Returns(typeof(object));
-        equalizationOptionsMock.Setup(eo => eo.ActualType).Returns(typeof(object));
-        return equalizationOptionsMock;
+        var equalizationOptions = Substitute.For<IEqualizationOptions>();
+        equalizationOptions.Equalize(Arg.Any<object>(), Arg.Any<object>()).Returns(x => internalEqualization(x[0], x[1]));
+        equalizationOptions.ExpectedType.Returns(typeof(object));
+        equalizationOptions.ActualType.Returns(typeof(object));
+        
+        return equalizationOptions;
     }
 }

--- a/TryAtSoftware.Equalizer.Core.Tests/TryAtSoftware.Equalizer.Core.Tests.csproj
+++ b/TryAtSoftware.Equalizer.Core.Tests/TryAtSoftware.Equalizer.Core.Tests.csproj
@@ -10,7 +10,7 @@
     <ItemGroup>
         <PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="all" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.3.0" />
         <PackageReference Include="SonarAnalyzer.CSharp" Version="10.15.0.120848" PrivateAssets="all" />
         <PackageReference Include="TryAtSoftware.Randomizer" Version="1.0.4" />
         <PackageReference Include="xunit" Version="2.4.2" />


### PR DESCRIPTION
## Pull Request Description 

Replaced Moq with NSubstitute in our tests (following the idea approached in other repositories within the TryAtSoftware organization).

## Motivation and Context

This PR addresses maintenance tasks to ensure that `Equalizer` remains stable and up-to-date.

## Checklist

- [x] I have tested these changes thoroughly.
- [x] My code follows the project's coding guidelines.
- [x] I have performed a self-review of my changes.
